### PR TITLE
FEAT : ODYA-49 서버 로그인 기능

### DIFF
--- a/data/src/main/java/com/weit/data/di/AuthModule.kt
+++ b/data/src/main/java/com/weit/data/di/AuthModule.kt
@@ -1,13 +1,14 @@
 package com.weit.data.di
 
-import android.content.Context
 import com.weit.data.repository.auth.AuthRepositoryImpl
+import com.weit.data.service.AuthService
+import com.weit.data.source.AuthDataSource
 import com.weit.domain.repository.auth.AuthRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
-import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
 import javax.inject.Singleton
 
 @Module
@@ -17,6 +18,12 @@ object AuthModule {
     @Singleton
     @Provides
     fun providesAuthRepository(
-        @ApplicationContext context: Context,
-    ): AuthRepository = AuthRepositoryImpl(context)
+        authDataSource: AuthDataSource,
+    ): AuthRepository = AuthRepositoryImpl(authDataSource)
+
+    @Singleton
+    @Provides
+    fun providesAuthService(
+        retrofit: Retrofit,
+    ): AuthService = retrofit.create(AuthService::class.java)
 }

--- a/data/src/main/java/com/weit/data/di/LoginModule.kt
+++ b/data/src/main/java/com/weit/data/di/LoginModule.kt
@@ -2,6 +2,7 @@ package com.weit.data.di
 
 import android.content.Context
 import com.weit.data.repository.auth.LoginRepositoryImpl
+import com.weit.data.source.AuthDataSource
 import com.weit.domain.repository.auth.LoginRepository
 import dagger.Module
 import dagger.Provides
@@ -17,5 +18,9 @@ class LoginModule {
     @Provides
     fun provideLoginRepository(
         @ActivityContext context: Context,
-    ): LoginRepository = LoginRepositoryImpl(context)
+        authDataSource: AuthDataSource,
+    ): LoginRepository = LoginRepositoryImpl(
+        context,
+        authDataSource,
+    )
 }

--- a/data/src/main/java/com/weit/data/model/auth/KakaoAccessToken.kt
+++ b/data/src/main/java/com/weit/data/model/auth/KakaoAccessToken.kt
@@ -1,0 +1,9 @@
+package com.weit.data.model.auth
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class KakaoAccessToken(
+    @field:Json(name = "accessToken") val token: String,
+)

--- a/data/src/main/java/com/weit/data/model/auth/UserRegistration.kt
+++ b/data/src/main/java/com/weit/data/model/auth/UserRegistration.kt
@@ -1,0 +1,14 @@
+package com.weit.data.model.auth
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class UserRegistration(
+    @field:Json(name = "username") val name: String,
+    @field:Json(name = "email") val email: String?,
+    @field:Json(name = "phoneNumber") val phoneNumber: String?,
+    @field:Json(name = "nickname") val nickname: String,
+    @field:Json(name = "gender") val gender: String,
+    @field:Json(name = "birthday") val birthday: List<Int>,
+)

--- a/data/src/main/java/com/weit/data/model/auth/UserTokenDTO.kt
+++ b/data/src/main/java/com/weit/data/model/auth/UserTokenDTO.kt
@@ -1,0 +1,9 @@
+package com.weit.data.model.auth
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class UserTokenDTO(
+    @field:Json(name = "firebaseCustomToken") val token: String,
+)

--- a/data/src/main/java/com/weit/data/repository/auth/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/weit/data/repository/auth/AuthRepositoryImpl.kt
@@ -1,7 +1,8 @@
 package com.weit.data.repository.auth
 
-import android.content.Context
 import com.kakao.sdk.user.UserApiClient
+import com.weit.data.source.AuthDataSource
+import com.weit.domain.model.auth.UserRegistrationInfo
 import com.weit.domain.repository.auth.AuthRepository
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
@@ -10,11 +11,17 @@ import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 
 class AuthRepositoryImpl @Inject constructor(
-    private val context: Context,
+    private val authDataSource: AuthDataSource,
 ) : AuthRepository {
 
     override suspend fun logout(): Result<Unit> {
         return logoutKakao().first()
+    }
+
+    override suspend fun register(info: UserRegistrationInfo): Result<Unit> {
+        return runCatching {
+            authDataSource.register(info)
+        }
     }
 
     private suspend fun logoutKakao(): Flow<Result<Unit>> = callbackFlow {

--- a/data/src/main/java/com/weit/data/repository/auth/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/weit/data/repository/auth/AuthRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.weit.data.repository.auth
 
 import com.kakao.sdk.user.UserApiClient
+import com.weit.data.model.auth.UserRegistration
 import com.weit.data.source.AuthDataSource
 import com.weit.domain.model.auth.UserRegistrationInfo
 import com.weit.domain.repository.auth.AuthRepository
@@ -20,7 +21,7 @@ class AuthRepositoryImpl @Inject constructor(
 
     override suspend fun register(info: UserRegistrationInfo): Result<Unit> {
         return runCatching {
-            authDataSource.register(info)
+            authDataSource.register(info.toUserRegistration())
         }
     }
 
@@ -34,4 +35,14 @@ class AuthRepositoryImpl @Inject constructor(
         }
         awaitClose { /* Do Nothing */ }
     }
+
+    private fun UserRegistrationInfo.toUserRegistration(): UserRegistration =
+        UserRegistration(
+            name = name,
+            email = email,
+            phoneNumber = phoneNumber,
+            nickname = nickname,
+            gender = gender,
+            birthday = birthday,
+        )
 }

--- a/data/src/main/java/com/weit/data/repository/auth/LoginRepositoryImpl.kt
+++ b/data/src/main/java/com/weit/data/repository/auth/LoginRepositoryImpl.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.kakao.sdk.common.model.ClientError
 import com.kakao.sdk.common.model.ClientErrorCause
 import com.kakao.sdk.user.UserApiClient
+import com.weit.data.model.auth.KakaoAccessToken
 import com.weit.data.model.auth.UserTokenDTO
 import com.weit.data.source.AuthDataSource
 import com.weit.domain.model.auth.UserToken
@@ -72,7 +73,7 @@ class LoginRepositoryImpl @Inject constructor(
     private suspend fun loginToServer(): Result<UserToken> {
         return authDataSource.getKakaoToken().first()?.let { token ->
             val result = kotlin.runCatching {
-                authDataSource.login(token).toUserToken()
+                authDataSource.login(KakaoAccessToken(token)).toUserToken()
             }
             if (result.isSuccess) {
                 Result.success(result.getOrThrow())

--- a/data/src/main/java/com/weit/data/repository/auth/LoginRepositoryImpl.kt
+++ b/data/src/main/java/com/weit/data/repository/auth/LoginRepositoryImpl.kt
@@ -4,6 +4,13 @@ import android.content.Context
 import com.kakao.sdk.common.model.ClientError
 import com.kakao.sdk.common.model.ClientErrorCause
 import com.kakao.sdk.user.UserApiClient
+import com.weit.data.model.auth.UserTokenDTO
+import com.weit.data.source.AuthDataSource
+import com.weit.domain.model.auth.UserToken
+import com.weit.domain.model.exception.UnKnownException
+import com.weit.domain.model.exception.auth.NeedUserRegistrationException
+import com.weit.domain.model.exception.auth.ServerLoginFailedException
+import com.weit.domain.model.exception.auth.UserNotFoundException
 import com.weit.domain.repository.auth.LoginRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -12,16 +19,26 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import okhttp3.internal.http.HTTP_INTERNAL_SERVER_ERROR
+import okhttp3.internal.http.HTTP_UNAUTHORIZED
+import retrofit2.HttpException
 import javax.inject.Inject
 
 class LoginRepositoryImpl @Inject constructor(
     private val context: Context,
+    private val authDataSource: AuthDataSource,
 ) : LoginRepository {
-    override suspend fun loginWithKakao(): Result<Unit> {
-        return if (UserApiClient.instance.isKakaoTalkLoginAvailable(context)) {
+    override suspend fun loginWithKakao(): Result<UserToken> {
+        // TODO 유효 토큰 검사 후 자동 로그인
+        val result = if (UserApiClient.instance.isKakaoTalkLoginAvailable(context)) {
             loginWithKakaoTalk().first()
         } else {
             loginWithKakaoAccount().first()
+        }
+        return if (result.isSuccess) {
+            loginToServer()
+        } else {
+            Result.failure(result.exceptionOrNull() ?: Exception())
         }
     }
 
@@ -51,4 +68,31 @@ class LoginRepositoryImpl @Inject constructor(
         }
         awaitClose { /* Do Nothing */ }
     }
+
+    private suspend fun loginToServer(): Result<UserToken> {
+        return authDataSource.getKakaoToken().first()?.let { token ->
+            val result = kotlin.runCatching {
+                authDataSource.login(token).toUserToken()
+            }
+            if (result.isSuccess) {
+                Result.success(result.getOrThrow())
+            } else {
+                Result.failure(handleServerLoginError(result.exceptionOrNull()!!))
+            }
+        } ?: Result.failure(UserNotFoundException())
+    }
+
+    private fun handleServerLoginError(t: Throwable): Throwable {
+        return if (t is HttpException) {
+            when (t.code()) {
+                HTTP_UNAUTHORIZED -> NeedUserRegistrationException()
+                HTTP_INTERNAL_SERVER_ERROR -> ServerLoginFailedException()
+                else -> UnKnownException()
+            }
+        } else {
+            t
+        }
+    }
+
+    private fun UserTokenDTO.toUserToken() = UserToken(token)
 }

--- a/data/src/main/java/com/weit/data/service/AuthService.kt
+++ b/data/src/main/java/com/weit/data/service/AuthService.kt
@@ -1,26 +1,23 @@
 package com.weit.data.service
 
+import com.weit.data.model.auth.KakaoAccessToken
+import com.weit.data.model.auth.UserRegistration
 import com.weit.data.model.auth.UserTokenDTO
-import retrofit2.http.Field
+import retrofit2.http.Body
 import retrofit2.http.FormUrlEncoded
 import retrofit2.http.POST
 
 interface AuthService {
 
-    @POST("/api/v1/auth/login")
+    @POST("/api/v1/auth/login/kakao")
     @FormUrlEncoded
     suspend fun login(
-        @Field("accessToken") accessToken: String,
+        @Body accessToken: KakaoAccessToken,
     ): UserTokenDTO
 
     @POST("/api/v1/auth/register/kakao")
     @FormUrlEncoded
     suspend fun register(
-        @Field("username") name: String,
-        @Field("email") email: String?,
-        @Field("phoneNumber") phoneNumber: String?,
-        @Field("nickname") nickname: String,
-        @Field("gender") gender: String,
-        @Field("birthday") birthday: List<Int>,
+        @Body userRegistration: UserRegistration,
     )
 }

--- a/data/src/main/java/com/weit/data/service/AuthService.kt
+++ b/data/src/main/java/com/weit/data/service/AuthService.kt
@@ -1,0 +1,26 @@
+package com.weit.data.service
+
+import com.weit.data.model.auth.UserTokenDTO
+import retrofit2.http.Field
+import retrofit2.http.FormUrlEncoded
+import retrofit2.http.POST
+
+interface AuthService {
+
+    @POST("/api/v1/auth/login")
+    @FormUrlEncoded
+    suspend fun login(
+        @Field("accessToken") accessToken: String,
+    ): UserTokenDTO
+
+    @POST("/api/v1/auth/register/kakao")
+    @FormUrlEncoded
+    suspend fun register(
+        @Field("username") name: String,
+        @Field("email") email: String?,
+        @Field("phoneNumber") phoneNumber: String?,
+        @Field("nickname") nickname: String,
+        @Field("gender") gender: String,
+        @Field("birthday") birthday: List<Int>,
+    )
+}

--- a/data/src/main/java/com/weit/data/source/AuthDataSource.kt
+++ b/data/src/main/java/com/weit/data/source/AuthDataSource.kt
@@ -2,9 +2,10 @@ package com.weit.data.source
 
 import com.kakao.sdk.auth.AuthApiClient
 import com.kakao.sdk.user.UserApiClient
+import com.weit.data.model.auth.KakaoAccessToken
+import com.weit.data.model.auth.UserRegistration
 import com.weit.data.model.auth.UserTokenDTO
 import com.weit.data.service.AuthService
-import com.weit.domain.model.auth.UserRegistrationInfo
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
@@ -14,17 +15,10 @@ class AuthDataSource @Inject constructor(
     private val service: AuthService,
 ) {
 
-    suspend fun login(accessToken: String): UserTokenDTO = service.login(accessToken)
+    suspend fun login(accessToken: KakaoAccessToken): UserTokenDTO = service.login(accessToken)
 
-    suspend fun register(info: UserRegistrationInfo) {
-        service.register(
-            name = info.name,
-            email = info.email,
-            phoneNumber = info.phoneNumber,
-            nickname = info.nickname,
-            gender = info.gender,
-            birthday = info.birthday,
-        )
+    suspend fun register(userRegistration: UserRegistration) {
+        service.register(userRegistration)
     }
 
     fun hasKakaoToken(): Boolean =

--- a/data/src/main/java/com/weit/data/source/AuthDataSource.kt
+++ b/data/src/main/java/com/weit/data/source/AuthDataSource.kt
@@ -1,0 +1,42 @@
+package com.weit.data.source
+
+import com.kakao.sdk.auth.AuthApiClient
+import com.kakao.sdk.user.UserApiClient
+import com.weit.data.model.auth.UserTokenDTO
+import com.weit.data.service.AuthService
+import com.weit.domain.model.auth.UserRegistrationInfo
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import javax.inject.Inject
+
+class AuthDataSource @Inject constructor(
+    private val service: AuthService,
+) {
+
+    suspend fun login(accessToken: String): UserTokenDTO = service.login(accessToken)
+
+    suspend fun register(info: UserRegistrationInfo) {
+        service.register(
+            name = info.name,
+            email = info.email,
+            phoneNumber = info.phoneNumber,
+            nickname = info.nickname,
+            gender = info.gender,
+            birthday = info.birthday,
+        )
+    }
+
+    fun hasKakaoToken(): Boolean =
+        AuthApiClient.instance.hasToken()
+
+    fun getKakaoToken(): Flow<String?> = callbackFlow {
+        UserApiClient.instance.accessTokenInfo { _, _ ->
+            trySend(getAccessToken())
+        }
+        awaitClose { /* Do Nothing */ }
+    }
+
+    private fun getAccessToken() =
+        AuthApiClient.instance.tokenManagerProvider.manager.getToken()?.accessToken
+}

--- a/domain/src/main/java/com/weit/domain/model/auth/UserRegistrationInfo.kt
+++ b/domain/src/main/java/com/weit/domain/model/auth/UserRegistrationInfo.kt
@@ -1,0 +1,10 @@
+package com.weit.domain.model.auth
+
+data class UserRegistrationInfo(
+    val name: String,
+    val email: String? = null,
+    val phoneNumber: String? = null,
+    val nickname: String,
+    val gender: String,
+    val birthday: List<Int>,
+)

--- a/domain/src/main/java/com/weit/domain/model/auth/UserToken.kt
+++ b/domain/src/main/java/com/weit/domain/model/auth/UserToken.kt
@@ -1,0 +1,5 @@
+package com.weit.domain.model.auth
+
+data class UserToken(
+    val token: String,
+)

--- a/domain/src/main/java/com/weit/domain/model/exception/UnKnownException.kt
+++ b/domain/src/main/java/com/weit/domain/model/exception/UnKnownException.kt
@@ -1,0 +1,3 @@
+package com.weit.domain.model.exception
+
+class UnKnownException : Exception()

--- a/domain/src/main/java/com/weit/domain/model/exception/auth/NeedUserRegistrationException.kt
+++ b/domain/src/main/java/com/weit/domain/model/exception/auth/NeedUserRegistrationException.kt
@@ -1,0 +1,6 @@
+package com.weit.domain.model.exception.auth
+
+import java.lang.Exception
+
+// 유효한 토큰이지만 서비스에 가입이 되지 않았다면 해당 에러를 반환합니다.
+class NeedUserRegistrationException : Exception()

--- a/domain/src/main/java/com/weit/domain/model/exception/auth/ServerLoginFailedException.kt
+++ b/domain/src/main/java/com/weit/domain/model/exception/auth/ServerLoginFailedException.kt
@@ -1,0 +1,6 @@
+package com.weit.domain.model.exception.auth
+
+import java.lang.Exception
+
+// 서버에서 리턴 토큰 생성에 실패하거나 회원 정보 요청 통신에 문제가 생기면 해당 에러를 반환합니다.
+class ServerLoginFailedException : Exception()

--- a/domain/src/main/java/com/weit/domain/model/exception/auth/UserNotFoundException.kt
+++ b/domain/src/main/java/com/weit/domain/model/exception/auth/UserNotFoundException.kt
@@ -1,0 +1,6 @@
+package com.weit.domain.model.exception.auth
+
+import java.lang.Exception
+
+// 카카오 로그인이 되지 않은 상태면 해당 에러를 반환합니다.
+class UserNotFoundException : Exception()

--- a/domain/src/main/java/com/weit/domain/repository/auth/AuthRepository.kt
+++ b/domain/src/main/java/com/weit/domain/repository/auth/AuthRepository.kt
@@ -1,5 +1,11 @@
 package com.weit.domain.repository.auth
 
+import com.weit.domain.model.auth.UserRegistrationInfo
+
 interface AuthRepository {
     suspend fun logout(): Result<Unit>
+
+    suspend fun register(
+        info: UserRegistrationInfo,
+    ): Result<Unit>
 }

--- a/domain/src/main/java/com/weit/domain/repository/auth/LoginRepository.kt
+++ b/domain/src/main/java/com/weit/domain/repository/auth/LoginRepository.kt
@@ -1,5 +1,7 @@
 package com.weit.domain.repository.auth
 
+import com.weit.domain.model.auth.UserToken
+
 interface LoginRepository {
-    suspend fun loginWithKakao(): Result<Unit>
+    suspend fun loginWithKakao(): Result<UserToken>
 }

--- a/domain/src/main/java/com/weit/domain/usecase/auth/LoginWithKakaoUseCase.kt
+++ b/domain/src/main/java/com/weit/domain/usecase/auth/LoginWithKakaoUseCase.kt
@@ -1,5 +1,6 @@
 package com.weit.domain.usecase.auth
 
+import com.weit.domain.model.auth.UserToken
 import com.weit.domain.repository.auth.LoginRepository
 import javax.inject.Inject
 
@@ -9,5 +10,5 @@ import javax.inject.Inject
 class LoginWithKakaoUseCase @Inject constructor(
     private val repository: LoginRepository,
 ) {
-    suspend operator fun invoke(): Result<Unit> = repository.loginWithKakao()
+    suspend operator fun invoke(): Result<UserToken> = repository.loginWithKakao()
 }

--- a/domain/src/main/java/com/weit/domain/usecase/auth/RegisterUserUseCase.kt
+++ b/domain/src/main/java/com/weit/domain/usecase/auth/RegisterUserUseCase.kt
@@ -1,0 +1,12 @@
+package com.weit.domain.usecase.auth
+
+import com.weit.domain.model.auth.UserRegistrationInfo
+import com.weit.domain.repository.auth.AuthRepository
+import javax.inject.Inject
+
+class RegisterUserUseCase @Inject constructor(
+    private val repository: AuthRepository,
+) {
+    suspend operator fun invoke(info: UserRegistrationInfo): Result<Unit> =
+        repository.register(info)
+}

--- a/presentation/src/main/java/com/weit/presentation/ui/login/LoginActivity.kt
+++ b/presentation/src/main/java/com/weit/presentation/ui/login/LoginActivity.kt
@@ -26,12 +26,14 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>(
         binding.btnLoginKakao.setOnClickListener {
             viewModel.onLoginWithKakao(loginWithKakaoUseCase)
         }
+        binding.btnToMain.setOnClickListener {
+            moveToMain()
+        }
     }
 
     override fun initCollector() {
         repeatOnStarted(this) {
             viewModel.loginEvent.collectLatest { token ->
-                Logger.t("MainTest").i(token)
                 moveToMain()
             }
         }

--- a/presentation/src/main/java/com/weit/presentation/ui/login/LoginActivity.kt
+++ b/presentation/src/main/java/com/weit/presentation/ui/login/LoginActivity.kt
@@ -30,7 +30,8 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>(
 
     override fun initCollector() {
         repeatOnStarted(this) {
-            viewModel.loginEvent.collectLatest {
+            viewModel.loginEvent.collectLatest { token ->
+                Logger.t("MainTest").i(token)
                 moveToMain()
             }
         }

--- a/presentation/src/main/java/com/weit/presentation/ui/login/LoginViewModel.kt
+++ b/presentation/src/main/java/com/weit/presentation/ui/login/LoginViewModel.kt
@@ -13,7 +13,7 @@ import javax.inject.Inject
 @HiltViewModel
 class LoginViewModel @Inject constructor() : ViewModel() {
 
-    private val _loginEvent = MutableEventFlow<Unit>()
+    private val _loginEvent = MutableEventFlow<String>()
     val loginEvent = _loginEvent.asEventFlow()
 
     private val _errorEvent = MutableEventFlow<Throwable>()
@@ -24,7 +24,7 @@ class LoginViewModel @Inject constructor() : ViewModel() {
         viewModelScope.launch {
             val result = loginWithKakaoUseCase()
             if (result.isSuccess) {
-                _loginEvent.emit(Unit)
+                _loginEvent.emit(result.getOrThrow().token)
             } else {
                 _errorEvent.emit(result.exceptionOrNull() ?: Exception())
             }

--- a/presentation/src/main/res/layout/activity_login.xml
+++ b/presentation/src/main/res/layout/activity_login.xml
@@ -13,4 +13,14 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"/>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btn_to_main"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="일단 메인으로"
+        app:layout_constraintTop_toBottomOf="@id/btn_login_kakao"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"/>
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
### 개요
* 서버 로그인 기능 추가

### 변경사항
* 서버 로그인 기능 추가
  * loginWithKakao에서 카카오 로그인에 성공하면 바로 서버 로그인 시도
* 회원가입 UseCase 추가 (아직 쓰진 않음)
* AccessToken을 가져오고 조회하는 DataSource 메소드 추가
  * 나중에 유저 토큰을 넣어야하는 api를 호출할때는 이 AccessToken이 들어갑니다.
* Login -> Main 프리패스 버튼 추가
  * 현재 서버 로그인을 성공할 수 없는 상태이므로 로그인을 안해도 넘어갈 수 있게 임시 버튼 추가

### 관련 지라 및 위키 링크
* [ODYA-49](https://weit.atlassian.net/browse/ODYA-49?atlOrigin=eyJpIjoiYzQ2MTk4YTNjYzVkNDEyMWIxZDRlMjFlNTM1ZTM4MWIiLCJwIjoiaiJ9)

### 리뷰어에게 하고 싶은 말
* 즈엉말 많은 코드가 추가됐지만 정작 로그인 기능을 사용하는 Presentation에서는 바뀐게 별로 없읍니다. 멀티 모듈의 장점이에요
* 현재는 서버 회원가입 기능을 안넣어서 로그인에 성공해도 401에러(유효한 토큰이지만 회원이 아님)이 나옵니다.